### PR TITLE
Crud tipo chamado

### DIFF
--- a/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
@@ -38,4 +38,9 @@ public class ControladorDeTipoChamado {
         var tipoChamadoOptional = servicoDeTipoChamado.arquivarChamadoById(idTipoChamado);
         return tipoChamadoOptional.isPresent() ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
     }
+
+    @GetMapping("/ativo")
+    ResponseEntity<List<TipoChamadoGetDto>> getTiposAtivos(){
+        return ResponseEntity.ok().body(servicoDeTipoChamado.findTipoChamadoByArquivado(false).stream().map(TipoChamadoGetDto::fromTipoChamado).toList());
+    }
 }

--- a/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
@@ -4,9 +4,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import rj.cefet.sacapi.dto.TipoChamadoGetDto;
 import rj.cefet.sacapi.dto.TipoChamadoPostDto;
+import rj.cefet.sacapi.modelo.TipoChamado;
 import rj.cefet.sacapi.servico.ServicoDeTipoChamado;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @CrossOrigin(origins = "", maxAge = 3600)
@@ -29,5 +31,11 @@ public class ControladorDeTipoChamado {
     @GetMapping
     ResponseEntity<List<TipoChamadoGetDto>> getAllTipoChamado(){
         return ResponseEntity.ok().body(servicoDeTipoChamado.findAllTipoChamado().stream().map(TipoChamadoGetDto::fromTipoChamado).toList());
+    }
+
+    @DeleteMapping("/{idTipoChamado}")
+    ResponseEntity<String> arquivarTipoChamado(@PathVariable String idTipoChamado){
+        var tipoChamadoOptional = servicoDeTipoChamado.arquivarChamadoById(idTipoChamado);
+        return tipoChamadoOptional.isPresent() ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
@@ -1,0 +1,36 @@
+package rj.cefet.sacapi.controlador;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import rj.cefet.sacapi.dto.TipoChamadoGetDto;
+import rj.cefet.sacapi.dto.TipoChamadoPostDto;
+import rj.cefet.sacapi.servico.ServicoDeTipoChamado;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin(origins = "", maxAge = 3600)
+@RequestMapping("/tipochamado")
+public class ControladorDeTipoChamado {
+    private ServicoDeTipoChamado servicoDeTipoChamado;
+
+    public ControladorDeTipoChamado(ServicoDeTipoChamado servicoDeTipoChamado) {
+        this.servicoDeTipoChamado = servicoDeTipoChamado;
+    }
+
+    @PostMapping
+    ResponseEntity<TipoChamadoGetDto> criarTipoChamado(@RequestBody TipoChamadoPostDto tipoChamadoPostDto){
+        //converter o dto em entidade e lista de motivos
+        var saved = servicoDeTipoChamado.salvar(
+                tipoChamadoPostDto.toTipoChamado(),
+                tipoChamadoPostDto.motivos()
+            );
+        var tipoChamadoGetDto = TipoChamadoGetDto.fromTipoChamado(saved);
+        return ResponseEntity.ok().body(tipoChamadoGetDto);
+    }
+
+    @GetMapping
+    ResponseEntity<List<TipoChamadoGetDto>> getAllTipoChamado(){
+        return ResponseEntity.ok().body(servicoDeTipoChamado.findAllTipoChamado().stream().map(TipoChamadoGetDto::fromTipoChamado).toList());
+    }
+}

--- a/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/controlador/ControladorDeTipoChamado.java
@@ -20,13 +20,10 @@ public class ControladorDeTipoChamado {
 
     @PostMapping
     ResponseEntity<TipoChamadoGetDto> criarTipoChamado(@RequestBody TipoChamadoPostDto tipoChamadoPostDto){
-        //converter o dto em entidade e lista de motivos
-        var saved = servicoDeTipoChamado.salvar(
-                tipoChamadoPostDto.toTipoChamado(),
-                tipoChamadoPostDto.motivos()
-            );
-        var tipoChamadoGetDto = TipoChamadoGetDto.fromTipoChamado(saved);
-        return ResponseEntity.ok().body(tipoChamadoGetDto);
+        var tipoChamado = tipoChamadoPostDto.toTipoChamado();
+        return ResponseEntity.ok().body(
+                TipoChamadoGetDto.fromTipoChamado(servicoDeTipoChamado.salvar(tipoChamado))
+        );
     }
 
     @GetMapping

--- a/src/main/java/rj/cefet/sacapi/dto/TipoChamadoGetDto.java
+++ b/src/main/java/rj/cefet/sacapi/dto/TipoChamadoGetDto.java
@@ -4,13 +4,18 @@ import rj.cefet.sacapi.modelo.Motivo;
 import rj.cefet.sacapi.modelo.TipoChamado;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-public record TipoChamadoGetDto(String tipo, Integer prioridade, List<String> motivos, Boolean arquivado) {
+public record TipoChamadoGetDto(String tipo, Integer prioridade, Set<String> motivos, Boolean arquivado) {
+    /**
+     * Converte um TipoChamado em um dto
+     */
     public static TipoChamadoGetDto fromTipoChamado(TipoChamado tipoChamado){
         return new TipoChamadoGetDto(
                 tipoChamado.getTipo(),
                 tipoChamado.getPrioridade(),
-                tipoChamado.getMotivoList().stream().map(Motivo::asString).toList(),
+                tipoChamado.getMotivoSet().stream().map(Motivo::asString).collect(Collectors.toSet()),
                 tipoChamado.isArquivado()
         );
     }

--- a/src/main/java/rj/cefet/sacapi/dto/TipoChamadoGetDto.java
+++ b/src/main/java/rj/cefet/sacapi/dto/TipoChamadoGetDto.java
@@ -1,0 +1,17 @@
+package rj.cefet.sacapi.dto;
+
+import rj.cefet.sacapi.modelo.Motivo;
+import rj.cefet.sacapi.modelo.TipoChamado;
+
+import java.util.List;
+
+public record TipoChamadoGetDto(String tipo, Integer prioridade, List<String> motivos, Boolean arquivado) {
+    public static TipoChamadoGetDto fromTipoChamado(TipoChamado tipoChamado){
+        return new TipoChamadoGetDto(
+                tipoChamado.getTipo(),
+                tipoChamado.getPrioridade(),
+                tipoChamado.getMotivoList().stream().map(Motivo::asString).toList(),
+                tipoChamado.isArquivado()
+        );
+    }
+}

--- a/src/main/java/rj/cefet/sacapi/dto/TipoChamadoPostDto.java
+++ b/src/main/java/rj/cefet/sacapi/dto/TipoChamadoPostDto.java
@@ -1,0 +1,16 @@
+package rj.cefet.sacapi.dto;
+
+import rj.cefet.sacapi.modelo.Motivo;
+import rj.cefet.sacapi.modelo.TipoChamado;
+
+import java.util.List;
+
+public record TipoChamadoPostDto(String tipo, List<String> motivos, Integer prioridade) {
+    public TipoChamado toTipoChamado(){
+        var tipoChamado = new TipoChamado();
+        tipoChamado.setArquivado(false);
+        tipoChamado.setTipo(tipo());
+        tipoChamado.setPrioridade(prioridade());
+        return tipoChamado;
+    }
+}

--- a/src/main/java/rj/cefet/sacapi/dto/TipoChamadoPostDto.java
+++ b/src/main/java/rj/cefet/sacapi/dto/TipoChamadoPostDto.java
@@ -3,14 +3,22 @@ package rj.cefet.sacapi.dto;
 import rj.cefet.sacapi.modelo.Motivo;
 import rj.cefet.sacapi.modelo.TipoChamado;
 
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-public record TipoChamadoPostDto(String tipo, List<String> motivos, Integer prioridade) {
+public record TipoChamadoPostDto(String tipo, Set<String> motivos, Integer prioridade) {
+    /**
+     * Converte este dto em um TipoChamado
+     * @return
+     */
     public TipoChamado toTipoChamado(){
         var tipoChamado = new TipoChamado();
         tipoChamado.setArquivado(false);
         tipoChamado.setTipo(tipo());
         tipoChamado.setPrioridade(prioridade());
+        //Converter lista de string em um set de motivos, já contendo os relacionamentos.
+        Set<Motivo> motivoList = motivos.stream().map(s -> new Motivo(s, tipoChamado)).collect(Collectors.toSet());
+        tipoChamado.setMotivoSet(motivoList);
         return tipoChamado;
     }
 }

--- a/src/main/java/rj/cefet/sacapi/modelo/Chamado.java
+++ b/src/main/java/rj/cefet/sacapi/modelo/Chamado.java
@@ -62,7 +62,7 @@ public class Chamado {
         if(this.tipoChamado == null){
             throw new IllegalStateException("O chamado não possui tipo");
         }
-        if (!this.tipoChamado.getMotivoList().contains(motivo)){
+        if (!this.tipoChamado.getMotivoSet().contains(motivo)){
             throw new IllegalArgumentException("O tipo deste chamado não admite o motivo {%s}".formatted(motivo.toString()));
         }
         this.motivo = motivo;

--- a/src/main/java/rj/cefet/sacapi/modelo/Motivo.java
+++ b/src/main/java/rj/cefet/sacapi/modelo/Motivo.java
@@ -2,15 +2,18 @@ package rj.cefet.sacapi.modelo;
 
 import jakarta.persistence.*;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 @Entity(name = "motivo")
 @Table(name = "motivo")
-public class Motivo {
+@IdClass(MotivoId.class)
+public class Motivo implements Serializable {
     @Id
     private String motivo;
     @ManyToOne
     @JoinColumn(name = "tipo_chamado")
+    @Id
     private TipoChamado tipoChamado;
 
     public Motivo() {
@@ -42,12 +45,12 @@ public class Motivo {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Motivo motivo1 = (Motivo) o;
-        return Objects.equals(getMotivo(), motivo1.getMotivo());
+        return Objects.equals(getMotivo(), motivo1.getMotivo()) && Objects.equals(getTipoChamado(), motivo1.getTipoChamado());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getMotivo());
+        return Objects.hash(getMotivo(), getTipoChamado());
     }
 
     public static Motivo fromString(String motivo) {
@@ -58,5 +61,13 @@ public class Motivo {
 
     public String asString() {
         return this.motivo;
+    }
+
+    @Override
+    public String toString() {
+        return "Motivo{" +
+                "motivo='" + motivo + '\'' +
+                ", tipoChamado=" + tipoChamado +
+                '}';
     }
 }

--- a/src/main/java/rj/cefet/sacapi/modelo/Motivo.java
+++ b/src/main/java/rj/cefet/sacapi/modelo/Motivo.java
@@ -16,6 +16,11 @@ public class Motivo {
     public Motivo() {
     }
 
+    public Motivo(String motivo, TipoChamado tipoChamado){
+        this.motivo = motivo;
+        this.tipoChamado = tipoChamado;
+    }
+
     public String getMotivo() {
         return motivo;
     }
@@ -43,5 +48,15 @@ public class Motivo {
     @Override
     public int hashCode() {
         return Objects.hash(getMotivo());
+    }
+
+    public static Motivo fromString(String motivo) {
+        Motivo motivo1 = new Motivo();
+        motivo1.setMotivo(motivo);
+        return motivo1;
+    }
+
+    public String asString() {
+        return this.motivo;
     }
 }

--- a/src/main/java/rj/cefet/sacapi/modelo/MotivoId.java
+++ b/src/main/java/rj/cefet/sacapi/modelo/MotivoId.java
@@ -1,0 +1,33 @@
+package rj.cefet.sacapi.modelo;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Chave composta de Motivo. Permitindo motivos de mesmo nome entre tipos diferentes, mas impedindo motivos de mesmo nome no mesmo tipo
+ */
+public class MotivoId implements Serializable {
+    private String motivo;
+    private TipoChamado tipoChamado;
+
+    public MotivoId() {
+    }
+
+    public MotivoId(String motivo, TipoChamado tipoChamado) {
+        this.motivo = motivo;
+        this.tipoChamado = tipoChamado;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MotivoId motivoId = (MotivoId) o;
+        return Objects.equals(motivo, motivoId.motivo) && Objects.equals(tipoChamado, motivoId.tipoChamado);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(motivo, tipoChamado);
+    }
+}

--- a/src/main/java/rj/cefet/sacapi/modelo/TipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/modelo/TipoChamado.java
@@ -2,20 +2,21 @@ package rj.cefet.sacapi.modelo;
 
 import jakarta.persistence.*;
 
-import java.util.List;
+import java.io.Serializable;
 import java.util.Objects;
+import java.util.Set;
 
 @Entity(name = "tipo_chamado")
 @Table(name = "tipo_chamado")
-public class TipoChamado {
+public class TipoChamado implements Serializable {
     @Id
     private String tipo;
     private int prioridade;
 
     private boolean arquivado;
 
-    @OneToMany(mappedBy = "tipoChamado")
-    private List<Motivo> motivoList;
+    @OneToMany(mappedBy = "tipoChamado", cascade = CascadeType.ALL)//cascade pois "motivo" não tem significado ou uso fora de um tipo.
+    private Set<Motivo> motivoSet;
     public TipoChamado() {
     }
 
@@ -43,16 +44,12 @@ public class TipoChamado {
         this.prioridade = prioridade;
     }
 
-    public List<Motivo> getMotivoList() {
-        return motivoList;
+    public Set<Motivo> getMotivoSet() {
+        return motivoSet;
     }
 
-    public void setMotivoList(List<Motivo> motivoList) {
-        this.motivoList = motivoList;
-    }
-
-    public void addMotivo(Motivo motivo){
-        this.motivoList.add(motivo);
+    public void setMotivoSet(Set<Motivo> motivoSet) {
+        this.motivoSet = motivoSet;
     }
 
     @Override

--- a/src/main/java/rj/cefet/sacapi/repositorio/RepositorioDeMotivo.java
+++ b/src/main/java/rj/cefet/sacapi/repositorio/RepositorioDeMotivo.java
@@ -2,6 +2,7 @@ package rj.cefet.sacapi.repositorio;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import rj.cefet.sacapi.modelo.Motivo;
+import rj.cefet.sacapi.modelo.MotivoId;
 
-public interface RepositorioDeMotivo extends JpaRepository<Motivo, String> {
+public interface RepositorioDeMotivo extends JpaRepository<Motivo, MotivoId> {
 }

--- a/src/main/java/rj/cefet/sacapi/repositorio/RepositorioDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/repositorio/RepositorioDeTipoChamado.java
@@ -3,5 +3,8 @@ package rj.cefet.sacapi.repositorio;
 import org.springframework.data.jpa.repository.JpaRepository;
 import rj.cefet.sacapi.modelo.TipoChamado;
 
+import java.util.List;
+
 public interface RepositorioDeTipoChamado extends JpaRepository<TipoChamado, String> {
+    List<TipoChamado> findByArquivado(boolean arquivado);
 }

--- a/src/main/java/rj/cefet/sacapi/servico/ServicoDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/servico/ServicoDeTipoChamado.java
@@ -6,7 +6,6 @@ import rj.cefet.sacapi.modelo.TipoChamado;
 import rj.cefet.sacapi.repositorio.RepositorioDeMotivo;
 import rj.cefet.sacapi.repositorio.RepositorioDeTipoChamado;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,20 +19,13 @@ public class ServicoDeTipoChamado {
         this.repositorioDeMotivo = repositorioDeMotivo;
     }
 
-    public TipoChamado salvar(TipoChamado tipoChamado, List<String> motivos){
-        //primeiro salvamos o tipo de chamado sem relacionamentos
-        TipoChamado salvo = repoTipoChamado.save(tipoChamado);
-        //criamos os motivos, já relacionados ao novo tipo de chamado
-        List<Motivo> motivosSalvos = repositorioDeMotivo.saveAll(
-                motivos.stream().map(s -> new Motivo(s, salvo)).toList()
-        );
-
-        //agora nosso objeto salvo está desatualizado, inserimos a lista de motivos criada, no nosso objeto de tipo
-        salvo.setMotivoList(motivosSalvos);
-        //Poderíamos salvar o tipo de chamado para atualizar a tabela caso necessário,
-        //ou resgatar a entidade diretamente do banco de dados, mas neste caso não será necessário.
-        //Apenas retornamos o objeto atualizado.
-        return salvo;
+    /**
+     * Salva um TipoChamado juntamente com seus Motivos.
+     * @param tipoChamado
+     * @return O tipo persistido.
+     */
+    public TipoChamado salvar(TipoChamado tipoChamado){
+        return repoTipoChamado.save(tipoChamado);
     }
 
 

--- a/src/main/java/rj/cefet/sacapi/servico/ServicoDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/servico/ServicoDeTipoChamado.java
@@ -1,0 +1,61 @@
+package rj.cefet.sacapi.servico;
+
+import org.springframework.stereotype.Service;
+import rj.cefet.sacapi.modelo.Motivo;
+import rj.cefet.sacapi.modelo.TipoChamado;
+import rj.cefet.sacapi.repositorio.RepositorioDeMotivo;
+import rj.cefet.sacapi.repositorio.RepositorioDeTipoChamado;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ServicoDeTipoChamado {
+    private RepositorioDeTipoChamado repoTipoChamado;
+    private RepositorioDeMotivo repositorioDeMotivo;
+
+    public ServicoDeTipoChamado(RepositorioDeTipoChamado repoTipoChamado, RepositorioDeMotivo repositorioDeMotivo) {
+        this.repoTipoChamado = repoTipoChamado;
+        this.repositorioDeMotivo = repositorioDeMotivo;
+    }
+
+    public TipoChamado salvar(TipoChamado tipoChamado, List<String> motivos){
+        //primeiro salvamos o tipo de chamado sem relacionamentos
+        TipoChamado salvo = repoTipoChamado.save(tipoChamado);
+        //criamos os motivos, já relacionados ao novo tipo de chamado
+        List<Motivo> motivosSalvos = repositorioDeMotivo.saveAll(
+                motivos.stream().map(s -> new Motivo(s, salvo)).toList()
+        );
+
+        //agora nosso objeto salvo está desatualizado, inserimos a lista de motivos criada, no nosso objeto de tipo
+        salvo.setMotivoList(motivosSalvos);
+        //Poderíamos salvar o tipo de chamado para atualizar a tabela caso necessário,
+        //ou resgatar a entidade diretamente do banco de dados, mas neste caso não será necessário.
+        //Apenas retornamos o objeto atualizado.
+        return salvo;
+    }
+
+
+    /**
+     * Arquiva um tipo de chamado
+     * @param id
+     * @return Um Optional contendo o tipo chamado arquivado. O optional é vazio caso o tipo de chamado não exista.
+     */
+    public Optional<TipoChamado> arquivarChamadoById(String id){
+        Optional<TipoChamado> tipoChamadoOptional = repoTipoChamado.findById(id);//acha o tipo
+        if (tipoChamadoOptional.isEmpty()){return tipoChamadoOptional;}//retorna optional vazio caso não exista
+        TipoChamado tipoChamado = tipoChamadoOptional.get();
+        tipoChamado.setArquivado(true);
+        TipoChamado tipoChamadoArquivado = repoTipoChamado.save(tipoChamado);//arquiva o tipo
+        return Optional.of(tipoChamadoArquivado);
+    }
+
+    public List<TipoChamado> findTipoChamadoByArquivado(boolean arquivado){
+        return repoTipoChamado.findByArquivado(arquivado);
+    }
+
+    public List<TipoChamado> findAllTipoChamado() {
+        return repoTipoChamado.findAll();
+    }
+}

--- a/src/main/java/rj/cefet/sacapi/servico/ServicoDeTipoChamado.java
+++ b/src/main/java/rj/cefet/sacapi/servico/ServicoDeTipoChamado.java
@@ -37,9 +37,11 @@ public class ServicoDeTipoChamado {
     public Optional<TipoChamado> arquivarChamadoById(String id){
         Optional<TipoChamado> tipoChamadoOptional = repoTipoChamado.findById(id);//acha o tipo
         if (tipoChamadoOptional.isEmpty()){return tipoChamadoOptional;}//retorna optional vazio caso não exista
-        TipoChamado tipoChamado = tipoChamadoOptional.get();
+
+        var tipoChamado = tipoChamadoOptional.get();
         tipoChamado.setArquivado(true);
-        TipoChamado tipoChamadoArquivado = repoTipoChamado.save(tipoChamado);//arquiva o tipo
+        var tipoChamadoArquivado = repoTipoChamado.save(tipoChamado);//arquiva o tipo
+
         return Optional.of(tipoChamadoArquivado);
     }
 


### PR DESCRIPTION
Crud dos tipos de chamado

## Endpoints adicionados
[/tipochamado](https://igor-da-silvarodrigues.github.io/sacapi/#/TipoChamado/createTipoChamado) (POST)
[/tipochamado](https://igor-da-silvarodrigues.github.io/sacapi/#/TipoChamado/findAllTipoChamado) (GET)
[/tipochamado/{idTipoChamado}](https://igor-da-silvarodrigues.github.io/sacapi/#/TipoChamado/deleteTipoChamado) (DELETE)
[/tipochamado/ativo] (GET) - não previsto, busca apenas tipos ativos.

## Mudanças importantes
- Chave primária de `Motivo` agora é uma chave composta do nome do `Motivo `e do `TipoChamado`.
