### PR TITLE
Adicionar guard de seguranca

### DIFF
--- a/src/main/java/rj/cefet/sacapi/controlador/ControladorDeAutenticacao.java
+++ b/src/main/java/rj/cefet/sacapi/controlador/ControladorDeAutenticacao.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -45,6 +46,7 @@ public class ControladorDeAutenticacao {
     }
 
     @PostMapping("/register/discente")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<String> register(@RequestBody @Valid RegisterDiscenteDto dto){
         Discente discente = new Discente();
         discente.setCep(dto.cep());
@@ -61,6 +63,7 @@ public class ControladorDeAutenticacao {
     }
 
     @PostMapping("/register/administrador")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<String> registerAdmin(@RequestBody @Valid RegisterAdministradorDto dto){
         Administrador administrador = new Administrador();
         administrador.setCep(dto.cep());

--- a/src/main/java/rj/cefet/sacapi/execao/ControladorDeExcecao.java
+++ b/src/main/java/rj/cefet/sacapi/execao/ControladorDeExcecao.java
@@ -2,6 +2,7 @@ package rj.cefet.sacapi.execao;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-
+import org.springframework.security.access.AccessDeniedException;
 import javax.naming.AuthenticationException;
 
 @ControllerAdvice
@@ -44,5 +45,10 @@ public class ControladorDeExcecao {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<String> handleNoResourceFoundException(NoResourceFoundException ex){
         return ResponseEntity.notFound().build();
+    }
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<String> handleAccessDeniedException(AccessDeniedException ex){
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Acesso não autorizado");
     }
 }

--- a/src/main/java/rj/cefet/sacapi/seguranca/ConfiguracaoDeSeguranca.java
+++ b/src/main/java/rj/cefet/sacapi/seguranca/ConfiguracaoDeSeguranca.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,6 +18,7 @@ import rj.cefet.sacapi.seguranca.servico.ServicoDeAutenticacao;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class ConfiguracaoDeSeguranca {
     private ServicoDeAutenticacao servicoDeAutenticacao;
     private FiltroDeSeguranca filtro;
@@ -33,11 +35,9 @@ public class ConfiguracaoDeSeguranca {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/login").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/register/**").hasAuthority("ROLE_ADMIN")
-                        .anyRequest().authenticated())
-                .addFilterBefore(filtro, UsernamePasswordAuthenticationFilter.class)
+                        .anyRequest().authenticated()
+                ).addFilterBefore(filtro, UsernamePasswordAuthenticationFilter.class)
                 .build();
-                // CRIAR UM GUARD PARA SEGURANÇA
     }
 
     @Bean


### PR DESCRIPTION
Substituir `requestMatcher` de registro por anotações de método, permitindo capturar as exceções de permissão no `ControladorDeExeção` e retornar um erro 401 ao invés de um erro 403.